### PR TITLE
Changes to prepare for il2cpp to use as a subrepo

### DIFF
--- a/Unity.Options.Tests/Unity.Options.Tests.csproj
+++ b/Unity.Options.Tests/Unity.Options.Tests.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Unity.Options.Tests/Unity.Options.Tests.csproj
+++ b/Unity.Options.Tests/Unity.Options.Tests.csproj
@@ -12,6 +12,10 @@
     <AssemblyName>Unity.Options.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <!-- For some reason xbuild on OSX doesn't seem to fine SolutionDirectory, but it does have SolutionDir
+         And although SolutionDir does seem to work for xbuild and msbuild, R# intellisense is not happy about it
+         So to work around this, if SolutionDirectory is not defined, define it to SolutionDir-->
+    <SolutionDirectory Condition=" '$(SolutionDirectory)' == '' ">$(SolutionDir)</SolutionDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Unity.Options/Unity.Options.csproj
+++ b/Unity.Options/Unity.Options.csproj
@@ -13,12 +13,16 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- For some reason xbuild on OSX doesn't seem to fine SolutionDirectory, but it does have SolutionDir
+         And although SolutionDir does seem to work for xbuild and msbuild, R# intellisense is not happy about it
+         So to work around this, if SolutionDirectory is not defined, define it to SolutionDir-->
+    <SolutionDirectory Condition=" '$(SolutionDirectory)' == '' ">$(SolutionDir)</SolutionDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/UnityEngine.Options.Tests.AnotherReference/UnityEngine.Options.Tests.AnotherReference.csproj
+++ b/UnityEngine.Options.Tests.AnotherReference/UnityEngine.Options.Tests.AnotherReference.csproj
@@ -12,6 +12,10 @@
     <AssemblyName>UnityEngine.Options.Tests.AnotherReference</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <!-- For some reason xbuild on OSX doesn't seem to fine SolutionDirectory, but it does have SolutionDir
+         And although SolutionDir does seem to work for xbuild and msbuild, R# intellisense is not happy about it
+         So to work around this, if SolutionDirectory is not defined, define it to SolutionDir-->
+    <SolutionDirectory Condition=" '$(SolutionDirectory)' == '' ">$(SolutionDir)</SolutionDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/UnityEngine.Options.Tests.AnotherReference/UnityEngine.Options.Tests.AnotherReference.csproj
+++ b/UnityEngine.Options.Tests.AnotherReference/UnityEngine.Options.Tests.AnotherReference.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/UnityEngine.Options.Tests.ExternalReference/UnityEngine.Options.Tests.ExternalReference.csproj
+++ b/UnityEngine.Options.Tests.ExternalReference/UnityEngine.Options.Tests.ExternalReference.csproj
@@ -12,6 +12,10 @@
     <AssemblyName>UnityEngine.Options.Tests.ExternalReference</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <!-- For some reason xbuild on OSX doesn't seem to fine SolutionDirectory, but it does have SolutionDir
+         And although SolutionDir does seem to work for xbuild and msbuild, R# intellisense is not happy about it
+         So to work around this, if SolutionDirectory is not defined, define it to SolutionDir-->
+    <SolutionDirectory Condition=" '$(SolutionDirectory)' == '' ">$(SolutionDir)</SolutionDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/UnityEngine.Options.Tests.ExternalReference/UnityEngine.Options.Tests.ExternalReference.csproj
+++ b/UnityEngine.Options.Tests.ExternalReference/UnityEngine.Options.Tests.ExternalReference.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>../build/</OutputPath>
+    <OutputPath>$(SolutionDirectory)/build/</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Use $(SolutionDirectory) as root so il2cpp.sln can change output location.

Some extra logic to deal with xbuild not knowing what SolutionDirectory is

Expose a bit more control over type collection for il2cpp so that we can keep some
netcore complexities out of Unity.Options