### PR TITLE
Test for new response file handling code

### DIFF
--- a/Unity.Options.Tests/Fixtures.cs
+++ b/Unity.Options.Tests/Fixtures.cs
@@ -56,7 +56,26 @@ namespace Unity.Options.Tests
         public static float FloatValue;
         public static double DoubleValue;
         public static bool BoolValue;
-        public static string StringValue;
+        public static string StringValueNoSpaces;
+        public static string StringValueWithSpaces;
+
+        public static void SetupDefaults()
+        {
+            CharValue = (char)0;
+            ByteValue = 0;
+            SByteValue = 0;
+            ShortValue = 0;
+            UShortValue = 0;
+            IntValue = 0;
+            UIntValue = 0;
+            LongValue = 0;
+            ULongValue = 0;
+            FloatValue = 0;
+            DoubleValue = 0;
+            BoolValue = false;
+            StringValueNoSpaces = string.Empty;
+            StringValueWithSpaces = string.Empty;
+        }
     }
 
     [ProgramOptions]

--- a/Unity.Options.Tests/OptionsTests.cs
+++ b/Unity.Options.Tests/OptionsTests.cs
@@ -107,7 +107,8 @@ namespace Unity.Options.Tests
                 "--float-value=10.42",
                 "--double-value=11.33",
                 "--bool-value",
-                "--string-value=gabriele farina"
+                "--string-value-with-spaces=gabriele farina",
+                "--string-value-no-spaces=gabrielefarina"
             };
             var types = new[] { typeof(BasicTypesOptions) };
 
@@ -125,7 +126,8 @@ namespace Unity.Options.Tests
             Assert.AreEqual(10.42f, BasicTypesOptions.FloatValue);
             Assert.AreEqual(11.33, BasicTypesOptions.DoubleValue);
             Assert.AreEqual(true, BasicTypesOptions.BoolValue);
-            Assert.AreEqual("gabriele farina", BasicTypesOptions.StringValue);
+            Assert.AreEqual("gabriele farina", BasicTypesOptions.StringValueWithSpaces);
+            Assert.AreEqual("gabrielefarina", BasicTypesOptions.StringValueNoSpaces);
         }
 
         [Test]
@@ -597,7 +599,7 @@ namespace Unity.Options.Tests
         [Test]
         public void OptionNameForOnStringField()
         {
-            Assert.AreEqual("--string-value", OptionsParser.OptionNameFor(typeof(BasicTypesOptions), nameof(BasicTypesOptions.StringValue)));
+            Assert.AreEqual("--string-value-with-spaces", OptionsParser.OptionNameFor(typeof(BasicTypesOptions), nameof(BasicTypesOptions.StringValueWithSpaces)));
         }
 
         [Test]

--- a/Unity.Options.Tests/ResponseFileTests.cs
+++ b/Unity.Options.Tests/ResponseFileTests.cs
@@ -67,5 +67,157 @@ namespace Unity.Options.Tests
                 Assert.Throws<FileNotFoundException>(() => OptionsParser.Prepare(commandLine, types));
             }
         }
+        
+        [Test]
+        public void VerifyOptionsFromResponseFileMultiLine()
+        {
+            using (var tempFile = TempFile.CreateRandom())
+            {
+                using (var writer = new StreamWriter(tempFile.Path))
+                {
+                    writer.WriteLine("--char-value=1");
+                    writer.WriteLine("--byte-value=2");
+                    writer.WriteLine("--s-byte-value=3");
+                    writer.WriteLine("--short-value=4");
+                    writer.WriteLine("--u-short-value=5");
+                    writer.WriteLine("--int-value=6");
+                    writer.WriteLine("--u-int-value=7");
+                    writer.WriteLine("--long-value=8");
+                    writer.WriteLine("--u-long-value=9");
+                    writer.WriteLine("--float-value=10.42");
+                    writer.WriteLine("--double-value=11.33");
+                    writer.WriteLine("--bool-value");
+                    writer.WriteLine("--string-value-with-spaces=\"value with spaces\"");
+                    writer.WriteLine("--string-value-no-spaces=valuewithoutspaces");
+                }
+
+                var commandLine = new[]
+                {
+                    $"@\"{tempFile.Path}\""
+                };
+
+                BasicTypesOptions.SetupDefaults();
+                var types = new[] { typeof(BasicTypesOptions) };
+
+                OptionsParser.Prepare(commandLine, types);
+                VerifyResponseFileOptions();
+            }
+        }
+
+        [Test]
+        public void VerifyOptionsFromResponseFileSingleLine()
+        {
+            using (var tempFile = TempFile.CreateRandom())
+            {
+                using (var writer = new StreamWriter(tempFile.Path))
+                {
+                    writer.Write("--char-value=1");
+                    writer.Write(" ");
+                    writer.Write("--byte-value=2");
+                    writer.Write(" ");
+                    writer.Write("--s-byte-value=3");
+                    writer.Write(" ");
+                    writer.Write("--short-value=4");
+                    writer.Write(" ");
+                    writer.Write("--u-short-value=5");
+                    writer.Write(" ");
+                    writer.Write("--int-value=6");
+                    writer.Write(" ");
+                    writer.Write("--u-int-value=7");
+                    writer.Write(" ");
+                    writer.Write("--long-value=8");
+                    writer.Write(" ");
+                    writer.Write("--u-long-value=9");
+                    writer.Write(" ");
+                    writer.Write("--float-value=10.42");
+                    writer.Write(" ");
+                    writer.Write("--double-value=11.33");
+                    writer.Write(" ");
+                    writer.Write("--bool-value");
+                    writer.Write(" ");
+                    writer.Write("--string-value-with-spaces=\"value with spaces\"");
+                    writer.Write(" ");
+                    writer.Write("--string-value-no-spaces=valuewithoutspaces");
+                }
+
+                var commandLine = new[]
+                {
+                    $"@\"{tempFile.Path}\""
+                };
+
+                BasicTypesOptions.SetupDefaults();
+                var types = new[] { typeof(BasicTypesOptions) };
+
+                OptionsParser.Prepare(commandLine, types);
+                VerifyResponseFileOptions();
+            }
+        }
+
+        [Test]
+        public void VerifyOptionsFromResponseFileMixedLines()
+        {
+            using (var tempFile = TempFile.CreateRandom())
+            {
+                using (var writer = new StreamWriter(tempFile.Path))
+                {
+                    writer.Write("--char-value=1");
+                    writer.Write(" ");
+                    writer.Write("--byte-value=2");
+                    writer.Write(" ");
+                    writer.Write("--s-byte-value=3");
+                    writer.Write(" ");
+                    writer.Write("--short-value=4");
+                    writer.WriteLine();
+                    writer.Write("--u-short-value=5");
+                    writer.Write(" ");
+                    writer.Write("--int-value=6");
+                    writer.Write(" ");
+                    writer.Write("--u-int-value=7");
+                    writer.WriteLine();
+                    writer.Write("--long-value=8");
+                    writer.Write(" ");
+                    writer.Write("--u-long-value=9");
+                    writer.Write(" ");
+                    writer.Write("--float-value=10.42");
+                    writer.Write(" ");
+                    writer.Write("--double-value=11.33");
+                    writer.WriteLine();
+                    writer.Write("--bool-value");
+                    writer.Write(" ");
+                    writer.Write("--string-value-with-spaces=\"value with spaces\"");
+                    writer.Write(" ");
+                    writer.Write("--string-value-no-spaces=valuewithoutspaces");
+                }
+
+                var commandLine = new[]
+                {
+                    $"@\"{tempFile.Path}\""
+                };
+
+                BasicTypesOptions.SetupDefaults();
+                var types = new[] { typeof(BasicTypesOptions) };
+
+                OptionsParser.Prepare(commandLine, types);
+                VerifyResponseFileOptions();
+            }
+        }
+
+        static void VerifyResponseFileOptions()
+        {
+            Assert.AreEqual('1', BasicTypesOptions.CharValue);
+            Assert.AreEqual(2, BasicTypesOptions.ByteValue);
+            Assert.AreEqual(3, BasicTypesOptions.SByteValue);
+            Assert.AreEqual(4, BasicTypesOptions.ShortValue);
+            Assert.AreEqual(5, BasicTypesOptions.UShortValue);
+            Assert.AreEqual(6, BasicTypesOptions.IntValue);
+            Assert.AreEqual(7, BasicTypesOptions.UIntValue);
+            Assert.AreEqual(8, BasicTypesOptions.LongValue);
+            Assert.AreEqual(9, BasicTypesOptions.ULongValue);
+            Assert.AreEqual(10.42f, BasicTypesOptions.FloatValue);
+            Assert.AreEqual(11.33, BasicTypesOptions.DoubleValue);
+            Assert.AreEqual(true, BasicTypesOptions.BoolValue);
+            Assert.AreEqual("value with spaces", BasicTypesOptions.StringValueWithSpaces);
+            Assert.AreEqual("valuewithoutspaces", BasicTypesOptions.StringValueNoSpaces);
+        }
     }
 }

--- a/Unity.Options/Options.cs
+++ b/Unity.Options/Options.cs
@@ -810,6 +810,10 @@ namespace NDesk.Options
                 if (arg[0] == '@')
                 {
                     var path = arg.Substring(1);
+
+                    if (path[0] == '"' && path[path.Length - 1] == '"')
+                        path = path.Substring(1, path.Length - 2);
+
                     if (!Path.IsPathRooted(path))
                         path = Path.Combine(currentDirectory, path);
                     


### PR DESCRIPTION
* Adding tests that exercise new ability (code was copied from Mono
linker) to have multiple options on the same line or different lines in
response files instead of just on separate lines.
* Added support for a quoted response file path on the command line.