### PR TITLE
Recreate enhancement and fix

### DIFF
--- a/Unity.Options.Tests/Fixtures.cs
+++ b/Unity.Options.Tests/Fixtures.cs
@@ -307,4 +307,12 @@ namespace Unity.Options.Tests
 
         public static string[] CollectionValue2;
     }
+    
+    [ProgramOptions]
+    public sealed class RecreateOptions2
+    {
+        public static string StringValue1;
+
+        public const string ShouldNotBeIncluded = "No!";
+    }
 }

--- a/Unity.Options.Tests/OptionsTests.cs
+++ b/Unity.Options.Tests/OptionsTests.cs
@@ -731,5 +731,33 @@ namespace Unity.Options.Tests
             var result = OptionsParser.RecreateArgumentsFromCurrentState(typeof(RecreateOptions));
             Assert.That(result, Is.EquivalentTo(expected));
         }
+        
+        [Test]
+        public void TestRecreateArgumentsFromCurrentStateCanBeFiltered()
+        {
+            RecreateOptions.StringValue1 = "Hello";
+            RecreateOptions.BoolValue1 = true;
+            RecreateOptions.CollectionValue1 = new[] {"Foo", "Bar"};
+
+            var expected = new[] {"--string-value1=Hello", "--collection-value1=Foo", "--collection-value1=Bar"};
+            var result = OptionsParser.RecreateArgumentsFromCurrentState(typeof(RecreateOptions), (field, value) =>
+            {
+                if (field.Name == nameof(RecreateOptions.BoolValue1))
+                    return false;
+
+                return true;
+            });
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+        
+        [Test]
+        public void TestRecreateArgumentsFromCurrentStateDoesNotIncludeConstsAreOptions()
+        {
+            RecreateOptions2.StringValue1 = "Hello";
+
+            var expected = new[] {"--string-value1=Hello" };
+            var result = OptionsParser.RecreateArgumentsFromCurrentState(typeof(RecreateOptions2));
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
     }
 }


### PR DESCRIPTION
Allow filtering during recreation.

const fields should not be treated as options.